### PR TITLE
Add a spout to read from a mongodb tailable cursor

### DIFF
--- a/storm-contrib-mongo/src/main/java/storm/contrib/mongo/MongoSpout.java
+++ b/storm-contrib-mongo/src/main/java/storm/contrib/mongo/MongoSpout.java
@@ -1,0 +1,166 @@
+package storm.contrib.mongo;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import backtype.storm.spout.SpoutOutputCollector;
+import backtype.storm.task.TopologyContext;
+import backtype.storm.topology.IRichSpout;
+import backtype.storm.utils.Utils;
+
+import com.mongodb.BasicDBObject;
+import com.mongodb.Bytes;
+import com.mongodb.DB;
+import com.mongodb.DBCursor;
+import com.mongodb.DBObject;
+import com.mongodb.Mongo;
+import com.mongodb.MongoException;
+
+/**
+* A Spout which consumes documents from a Mongodb tailable cursor.
+*
+* Subclasses should simply override two methods:
+* <ul>
+* <li>{@link #declareOutputFields(OutputFieldsDeclarer) declareOutputFields}
+* <li>{@link #dbObjectToStormTuple(DBObject) dbObjectToStormTuple}, which turns
+* a Mongo document into a Storm tuple matching the declared output fields.
+* </ul>
+*
+** <p>
+* <b>WARNING:</b> You can only use tailable cursors on capped collections.
+* 
+* @author Dan Beaulieu <danjacob.beaulieu@gmail.com>
+*
+*/
+public abstract class MongoSpout implements IRichSpout {
+
+	private SpoutOutputCollector collector;
+	
+	private LinkedBlockingQueue<DBObject> queue;
+	private final AtomicBoolean opened = new AtomicBoolean(false);
+	
+	private DB mongoDB;
+	private final DBObject query;
+	
+	private final String mongoHost;
+	private final int mongoPort;
+	private final String mongoDbName;
+	private final String mongoCollectionName;
+	
+	
+	public MongoSpout(String mongoHost, int mongoPort, String mongoDbName, String mongoCollectionName, DBObject query) {
+		
+		this.mongoHost = mongoHost;
+		this.mongoPort = mongoPort;
+		this.mongoDbName = mongoDbName;
+		this.mongoCollectionName = mongoCollectionName;
+		this.query = query;
+	}
+	
+	class TailableCursorThread extends Thread {
+		
+		LinkedBlockingQueue<DBObject> queue;
+		String mongoCollectionName;
+		DB mongoDB;
+		DBObject query;
+
+		public TailableCursorThread(LinkedBlockingQueue<DBObject> queue, DB mongoDB, String mongoCollectionName, DBObject query) {
+			
+			this.queue = queue;
+			this.mongoDB = mongoDB;
+			this.mongoCollectionName = mongoCollectionName;
+			this.query = query;
+		}
+
+		public void run() {
+			
+			while(opened.get()) {
+				try {
+					// create the cursor
+					mongoDB.requestStart();
+					final DBCursor cursor = mongoDB.getCollection(mongoCollectionName)
+												.find(query)
+												.sort(new BasicDBObject("$natural", 1))
+												.addOption(Bytes.QUERYOPTION_TAILABLE)
+												.addOption(Bytes.QUERYOPTION_AWAITDATA);
+					try {
+						while (opened.get() && cursor.hasNext()) {
+		                    final DBObject doc = cursor.next();
+		
+		                    if (doc == null) break;
+		
+		                    queue.put(doc);
+		                }
+					} finally {
+						try { 
+							if (cursor != null) cursor.close(); 
+						} catch (final Throwable t) { }
+	                    try { 
+	                    	mongoDB.requestDone(); 
+	                    	} catch (final Throwable t) { }
+	                }
+					
+					Utils.sleep(500);
+				} catch (final MongoException.CursorNotFound cnf) {
+					// rethrow only if something went wrong while we expect the cursor to be open.
+                    if (opened.get()) {
+                    	throw cnf;
+                    }
+                } catch (InterruptedException e) { break; }
+			}
+		};
+	}
+	
+	@Override
+	public void open(Map conf, TopologyContext context, SpoutOutputCollector collector) {
+		
+		this.collector = collector;
+		this.queue = new LinkedBlockingQueue<DBObject>(1000);
+		try {
+			this.mongoDB = new Mongo(this.mongoHost, this.mongoPort).getDB(this.mongoDbName);
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+
+		TailableCursorThread listener = new TailableCursorThread(this.queue, this.mongoDB, this.mongoCollectionName, this.query);
+		this.opened.set(true);
+		listener.start();
+	}
+
+	@Override
+	public void close() {
+		this.opened.set(false);
+	}
+
+	@Override
+	public void nextTuple() {
+		
+		DBObject dbo = this.queue.poll();
+		if(dbo == null) {
+            Utils.sleep(50);
+        } else {
+            this.collector.emit(dbObjectToStormTuple(dbo));
+        }
+	}
+
+	@Override
+	public void ack(Object msgId) {
+		// TODO Auto-generated method stub	
+	}
+
+	@Override
+	public void fail(Object msgId) {
+		// TODO Auto-generated method stub	
+	}
+
+	@Override
+	public boolean isDistributed() {
+		// TODO Auto-generated method stub
+		return false;
+	}
+	
+	public abstract List<Object> dbObjectToStormTuple(DBObject message);
+
+}

--- a/storm-contrib-mongo/src/main/java/storm/contrib/mongo/MongoTailableCursorTopology.java
+++ b/storm-contrib-mongo/src/main/java/storm/contrib/mongo/MongoTailableCursorTopology.java
@@ -1,0 +1,98 @@
+package storm.contrib.mongo;
+
+import static backtype.storm.utils.Utils.tuple;
+
+import java.util.Date;
+import java.util.List;
+
+import backtype.storm.Config;
+import backtype.storm.LocalCluster;
+import backtype.storm.topology.OutputFieldsDeclarer;
+import backtype.storm.topology.TopologyBuilder;
+import backtype.storm.tuple.Fields;
+import backtype.storm.utils.Utils;
+
+import com.mongodb.BasicDBObject;
+import com.mongodb.DBCollection;
+import com.mongodb.DBObject;
+import com.mongodb.Mongo;
+import com.mongodb.MongoURI;
+
+/**
+ * 
+ * Quick and dirty test. Parts of this should probably be turned into a proper
+ * integration test.
+ * 
+ * @author Dan Beaulieu
+ *
+ */
+public class MongoTailableCursorTopology {
+
+	/**
+	 * @param args
+	 */
+	public static void main(String[] args) throws Exception {
+		
+		
+		// mongo stuff
+        Mongo mongo = new Mongo(new MongoURI("mongodb://127.0.0.1:27017"));
+        mongo.dropDatabase("mongo_storm_tailable_cursor");
+        final BasicDBObject options = new BasicDBObject("capped", true);
+        options.put("size", 10000);
+        mongo.getDB("mongo_storm_tailable_cursor").createCollection("test", options);
+        final DBCollection coll = mongo.getDB("mongo_storm_tailable_cursor").getCollection("test");
+        
+		TopologyBuilder builder = new TopologyBuilder();
+        MongoSpout spout = new MongoSpout("localhost", 27017, "mongo_storm_tailable_cursor", "test", new BasicDBObject()) {
+
+        	/**
+			 * Ugh.
+			 */
+			private static final long serialVersionUID = 1L;
+
+			@Override
+        	public void declareOutputFields(OutputFieldsDeclarer declarer) {
+        		
+        		declarer.declare(new Fields("document"));	
+        	}
+
+			@Override
+			public List<Object> dbObjectToStormTuple(DBObject document) {
+				
+				return tuple(document);
+			}
+        	
+        };
+        builder.setSpout("1", spout);
+
+        
+        Config conf = new Config();
+        conf.setDebug(true);
+        
+        
+        LocalCluster cluster = new LocalCluster();
+        
+        cluster.submitTopology("test", conf, builder.createTopology());
+        
+        Runnable writer = new Runnable() {
+
+			@Override
+			public void run() {
+				for (int i=0; i < 1000; i++) {
+	                final BasicDBObject doc = new BasicDBObject("_id", i);
+	                doc.put("ts", new Date());
+	                coll.insert(doc);
+	            }
+			}
+		};
+		
+		new Thread(writer).start();
+		
+        Utils.sleep(10000);
+        cluster.shutdown();
+        
+        mongo.dropDatabase("mongo_storm_tailable_cursor");
+
+	}
+
+}


### PR DESCRIPTION
I've added a spout that reads from a mongodb tailable cursor. Also a hack of a test to show it all working. I tried to model the SQS spout as best I could. Let me know if you think it fits.
