### PR TITLE
Update storm-kafka/src/jvm/storm/kafka/ZkCoordinator.java

### DIFF
--- a/storm-kafka/src/jvm/storm/kafka/ZkCoordinator.java
+++ b/storm-kafka/src/jvm/storm/kafka/ZkCoordinator.java
@@ -129,7 +129,7 @@ public class ZkCoordinator implements PartitionCoordinator {
     }
     
     private boolean myOwnership(GlobalPartitionId id) {
-        int val = id.host.hashCode() + 23 * id.partition;        
+        int val = Math.abs(id.host.hashCode() + 23 * id.partition);        
         return val % _totalTasks == _taskIndex;
     }
     


### PR DESCRIPTION
Fixing a bug that causes partitions to be unassigned if the hash code of the "HostPort" is negative.
