### PR TITLE
Updating storm-contrib-mongo

### DIFF
--- a/storm-contrib-mongo/pom.xml
+++ b/storm-contrib-mongo/pom.xml
@@ -16,6 +16,7 @@
   	<dependency>
   	  <groupId>storm</groupId>
   	  <artifactId>storm</artifactId>
+  	  <version>0.7.2</version>
   	</dependency>
     <dependency>
       <groupId>org.mongodb</groupId>

--- a/storm-contrib-mongo/src/main/java/storm/contrib/mongo/MongoBolt.java
+++ b/storm-contrib-mongo/src/main/java/storm/contrib/mongo/MongoBolt.java
@@ -10,7 +10,7 @@ import com.mongodb.WriteConcern;
 
 import backtype.storm.task.OutputCollector;
 import backtype.storm.task.TopologyContext;
-import backtype.storm.topology.IRichBolt;
+import backtype.storm.topology.base.BaseRichBolt;
 import backtype.storm.tuple.Tuple;
 
 /**
@@ -22,7 +22,7 @@ import backtype.storm.tuple.Tuple;
  * @author Adrian Petrescu <apetresc@gmail.com>
  *
  */
-public abstract class MongoBolt implements IRichBolt {
+public abstract class MongoBolt extends BaseRichBolt {
 	private OutputCollector collector;
 	private DB mongoDB;
 	

--- a/storm-contrib-mongo/src/main/java/storm/contrib/mongo/MongoSpout.java
+++ b/storm-contrib-mongo/src/main/java/storm/contrib/mongo/MongoSpout.java
@@ -7,8 +7,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import backtype.storm.spout.SpoutOutputCollector;
 import backtype.storm.task.TopologyContext;
-import backtype.storm.topology.IRichSpout;
+import backtype.storm.Config;
+import backtype.storm.topology.base.BaseRichSpout;
 import backtype.storm.utils.Utils;
+import backtype.storm.topology.OutputFieldsDeclarer;
 
 import com.mongodb.BasicDBObject;
 import com.mongodb.Bytes;
@@ -34,7 +36,7 @@ import com.mongodb.MongoException;
 * @author Dan Beaulieu <danjacob.beaulieu@gmail.com>
 *
 */
-public abstract class MongoSpout implements IRichSpout {
+public abstract class MongoSpout extends BaseRichSpout {
 
 	private SpoutOutputCollector collector;
 	
@@ -155,11 +157,12 @@ public abstract class MongoSpout implements IRichSpout {
 		// TODO Auto-generated method stub	
 	}
 
-	@Override
-	public boolean isDistributed() {
-		// TODO Auto-generated method stub
-		return false;
-	}
+    @Override
+    public Map<String, Object> getComponentConfiguration() {
+        Config ret = new Config();
+        ret.setMaxTaskParallelism(1);
+        return ret;
+    }
 	
 	public abstract List<Object> dbObjectToStormTuple(DBObject message);
 


### PR DESCRIPTION
MongoBolt now extends BaseRichBolt
MongoSpout now extends BaseRichSpout
storm-contrib-mongo storm dependency set to 0.7.2
