### PR TITLE
Loading brokers from ZooKeeper with a sample topology.

### DIFF
--- a/storm-kafka/src/jvm/storm/kafka/HostPortZk.java
+++ b/storm-kafka/src/jvm/storm/kafka/HostPortZk.java
@@ -1,0 +1,17 @@
+package storm.kafka;
+
+public class HostPortZk extends HostPort {
+
+    public HostPortZk(String host, int port) {
+        super(host, port);
+    }
+
+    public HostPortZk(String host) {
+        super(host, 2181);
+    }
+
+    public String toString() {
+        return host + ":" + port;
+    }
+
+}

--- a/storm-kafka/src/jvm/storm/kafka/KafkaConfig.java
+++ b/storm-kafka/src/jvm/storm/kafka/KafkaConfig.java
@@ -48,4 +48,21 @@ public class KafkaConfig implements Serializable {
         }
         return ret;
     }
+
+    public static List<HostPortZk> convertHostsZk(List<String> hosts) {
+        List<HostPortZk> ret = new ArrayList<HostPortZk>();
+        for(String s: hosts) {
+            HostPortZk hp;
+            String[] spec = s.split(":");
+            if(spec.length==1) {
+                hp = new HostPortZk(spec[0]);
+            } else if (spec.length==2) {
+                hp = new HostPortZk(spec[0], Integer.parseInt(spec[1]));
+            } else {
+                throw new IllegalArgumentException("Invalid host specification: " + s);
+            }
+            ret.add(hp);
+        }
+        return ret;
+    }
 }

--- a/storm-kafka/src/jvm/storm/kafka/KafkaPartitionConnections.java
+++ b/storm-kafka/src/jvm/storm/kafka/KafkaPartitionConnections.java
@@ -1,18 +1,19 @@
 package storm.kafka;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
+
 import kafka.javaapi.consumer.SimpleConsumer;
 
 public class KafkaPartitionConnections {
     Map<Integer, SimpleConsumer> _kafka = new HashMap<Integer, SimpleConsumer>();
     
     KafkaConfig _config;
+    boolean zkBrokersLoaded = false;
     
     public KafkaPartitionConnections(KafkaConfig conf) {
         _config = conf;
     }
-    
+
     public SimpleConsumer getConsumer(int partition) {
         int hostIndex = partition / _config.partitionsPerHost;
         if(!_kafka.containsKey(hostIndex)) {

--- a/storm-kafka/src/jvm/storm/kafka/TestZooKeeperDiscoveryTopology.java
+++ b/storm-kafka/src/jvm/storm/kafka/TestZooKeeperDiscoveryTopology.java
@@ -1,0 +1,42 @@
+package storm.kafka;
+
+import backtype.storm.Config;
+import backtype.storm.LocalCluster;
+import backtype.storm.topology.BasicOutputCollector;
+import backtype.storm.topology.OutputFieldsDeclarer;
+import backtype.storm.topology.TopologyBuilder;
+import backtype.storm.topology.base.BaseBasicBolt;
+import backtype.storm.tuple.Tuple;
+import java.util.ArrayList;
+import java.util.List;
+
+public class TestZooKeeperDiscoveryTopology {
+    public static class PrinterBolt extends BaseBasicBolt {
+        @Override
+        public void declareOutputFields(OutputFieldsDeclarer declarer) {
+        }
+        @Override
+        public void execute(Tuple tuple, BasicOutputCollector collector) {
+            System.out.println(tuple.toString());
+        }
+    }
+
+    public static void main(String [] args) throws Exception {
+        List<String> zkDiscoveryServers = new ArrayList<String>();
+        zkDiscoveryServers.add("10.100.1.160:2181");
+        zkDiscoveryServers.add("10.100.1.161"); // can skip the port, defaults to 2181
+        zkDiscoveryServers.add("10.100.1.162");
+
+        SpoutConfig kafkaConf = new SpoutConfig(null, 1, "kafkastorm-zoo", "/kafkastorm-zoo", "kafkastorm-zoo");
+        kafkaConf.scheme = new StringScheme();
+        kafkaConf.hosts = ZooKeeperDiscovery.loadZkBrokers( zkDiscoveryServers, 20000, "/brokers/ids" );
+
+        LocalCluster cluster = new LocalCluster();
+        TopologyBuilder builder = new TopologyBuilder();
+        builder.setSpout("kafka", new KafkaSpout(kafkaConf), 3);
+        builder.setBolt("printer", new PrinterBolt())
+                .shuffleGrouping("kafka");
+        cluster.submitTopology("kafka-test", new Config(), builder.createTopology());
+        Thread.sleep(600000);
+    }
+}

--- a/storm-kafka/src/jvm/storm/kafka/ZooKeeperDiscovery.java
+++ b/storm-kafka/src/jvm/storm/kafka/ZooKeeperDiscovery.java
@@ -1,0 +1,90 @@
+package storm.kafka;
+
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.WatchedEvent;
+import org.apache.zookeeper.Watcher;
+import org.apache.zookeeper.ZooKeeper;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ZooKeeperDiscovery implements Watcher {
+
+    public void process(WatchedEvent event) {
+    }
+
+    public static List<HostPort> loadZkBrokers(List<String> zkHosts, int zkTimeout, String zkBrokersRoot) {
+        List<HostPortZk> _hosts = KafkaConfig.convertHostsZk(zkHosts);
+        List<String> discoveredHosts = new ArrayList<String>();
+        StringBuilder sb = new StringBuilder();
+        boolean first = true;
+        for (HostPortZk hpzk: _hosts) {
+            if (!first) sb.append(",");
+            sb.append( hpzk.toString() );
+            first = false;
+        }
+        try {
+            ZooKeeper zk = new ZooKeeper(sb.toString(), zkTimeout, new ZooKeeperDiscovery());
+            try {
+                if ( zk.exists(zkBrokersRoot, false) != null ) {
+
+                    try {
+                        List<String> brokers = zk.getChildren(zkBrokersRoot, false);
+                        for (String broker: brokers) {
+
+                            try {
+                                String data = new String( zk.getData(zkBrokersRoot+"/"+broker, false, null) );
+                                discoveredHosts.add(data.substring(data.indexOf(":")+1));
+                            } catch (InterruptedException ex) {
+                                try {
+                                    zk.close();
+                                } catch (InterruptedException ex3) { /* ignore */ }
+                                throw new IllegalStateException("ZooKeeper connection exception while loading data for " + zkBrokersRoot + "/" + broker + ".");
+                            } catch (KeeperException ex2) {
+                                try {
+                                    zk.close();
+                                } catch (InterruptedException ex3) { /* ignore */ }
+                                throw new IllegalStateException("ZooKeeper exception while loading data for " + zkBrokersRoot + "/" + broker + ".");
+                            }
+
+                        }
+                        try {
+                            zk.close();
+                        } catch (InterruptedException ex3) { /* ignore */ }
+                        return KafkaConfig.convertHosts(discoveredHosts);
+                    } catch (InterruptedException ex) {
+                        try {
+                            zk.close();
+                        } catch (InterruptedException ex3) { /* ignore */ }
+                        throw new IllegalStateException("ZooKeeper connection exception while loading children of " + zkBrokersRoot + ".");
+                    } catch (KeeperException ex2) {
+                        try {
+                            zk.close();
+                        } catch (InterruptedException ex3) { /* ignore */ }
+                        throw new IllegalStateException("ZooKeeper exception while loading children of " + zkBrokersRoot + ".");
+                    }
+
+                } else {
+                    try {
+                        zk.close();
+                    } catch (InterruptedException ex3) { /* ignore */ }
+                    throw new IllegalStateException(zkBrokersRoot + " not found on the discovery ZooKeeper.");
+                }
+            } catch (InterruptedException ex) {
+                try {
+                    zk.close();
+                } catch (InterruptedException ex3) { /* ignore */ }
+                throw new IllegalStateException("ZooKeeper connection exception while checking if the brokers path exists.");
+            } catch (KeeperException ex2) {
+                try {
+                    zk.close();
+                } catch (InterruptedException ex3) { /* ignore */ }
+                throw new IllegalStateException("ZooKeeper exception while checking if the brokers path exists.");
+            }
+        } catch (IOException ex) {
+            throw new IllegalStateException("Can't connect to the discovery ZooKeeper.");
+        }
+    }
+
+}


### PR DESCRIPTION
This is an example of how to load the brokers from the ZK server without changing the spout itself.
Code changed to use zookeeper jar instead of ZkClient.
