### PR TITLE
Fix out of range exception issue of partitioned Kafka spout

### DIFF
--- a/storm-kafka/src/jvm/storm/kafka/KafkaUtils.java
+++ b/storm-kafka/src/jvm/storm/kafka/KafkaUtils.java
@@ -20,6 +20,13 @@ public class KafkaUtils {
          if(lastMeta!=null) {
              offset = lastMeta.nextOffset;
          }
+         else {
+             long startTime = -2; // start from beginning
+             if(config.forceFromStart) {
+                 startTime = config.startOffsetTime;
+             }
+             offset = consumer.getOffsetsBefore(config.topic, partition % hosts.partitionsPerHost, startTime, 1)[0];
+         }
          ByteBufferMessageSet msgs;
          try {
             msgs = consumer.fetch(new FetchRequest(config.topic, partition % config.partitionsPerHost, offset, config.fetchSizeBytes));


### PR DESCRIPTION
I modified KafkaUtils::emitPartitionBatchNew method to fix the out of range exception when fetch messages from Kafka's topic.
This issue happens when there is no previous status in Zookeeper and the beginning offset of Kafka's brokers is non-zero.

-Binh
