### PR TITLE
Add option to change Kafka Spout output field name

### DIFF
--- a/storm-kafka/src/jvm/storm/kafka/StringScheme.java
+++ b/storm-kafka/src/jvm/storm/kafka/StringScheme.java
@@ -8,6 +8,17 @@ import java.util.List;
 
 public class StringScheme implements Scheme {
 
+    private String outputFieldName;
+
+    public StringScheme() {
+        this("str");
+    }
+
+    public StringScheme(String outputFieldName) {
+        this.outputFieldName = outputFieldName;
+
+    }
+
     public List<Object> deserialize(byte[] bytes) {
         try {
             return new Values(new String(bytes, "UTF-8"));
@@ -17,6 +28,7 @@ public class StringScheme implements Scheme {
     }
 
     public Fields getOutputFields() {
-        return new Fields("str");
+        return new Fields(outputFieldName);
     }
 }
+


### PR DESCRIPTION
Previously, when using a StringScheme, the Kafka spout would always
output the Kafka messages in a field called "str"; in this pull request,
the constructor to StringScheme takes a parameter that can be used in
place of "str", with "str" remaining the default.
