### PR TITLE
Treat NoRouteToHostException as a failed fetch

### DIFF
--- a/storm-kafka/src/jvm/storm/kafka/trident/KafkaUtils.java
+++ b/storm-kafka/src/jvm/storm/kafka/trident/KafkaUtils.java
@@ -1,6 +1,7 @@
 package storm.kafka.trident;
 
 import java.net.ConnectException;
+import java.net.NoRouteToHostException;
 import java.util.*;
 
 import backtype.storm.metric.api.CombinedMetric;
@@ -77,7 +78,7 @@ public class KafkaUtils {
             meanMetric.update(millis);
             maxMetric.update(millis);
          } catch(Exception e) {
-             if(e instanceof ConnectException) {
+             if(e instanceof ConnectException || e instanceof NoRouteToHostException) {
                  throw new FailedFetchException(e);
              } else {
                  throw new RuntimeException(e);


### PR DESCRIPTION
It's possible to get NoRouteToHostExceptions as well as ConnectExceptions when attempting to connect to the kafka broker. I don't think any others are possible, at least based on the docs at http://docs.oracle.com/javase/6/docs/api/java/net/SocketException.html (BindException and PortUnreachableException shouldn't be possible for TCP connects).
