### PR TITLE
upgrade as issue STORM-70:upgrade to curator-1.3.3, fix curator-framewor...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ lib/
 *.jar
 /storm-kafka/target/
 /storm-kafka/.idea/
+.idea
+.idea/*
+*.iml

--- a/storm-kafka/.gitignore
+++ b/storm-kafka/.gitignore
@@ -1,3 +1,4 @@
 classes/
 lib/
 pom.xml
+*.iml

--- a/storm-kafka/project.clj
+++ b/storm-kafka/project.clj
@@ -1,4 +1,4 @@
-(defproject storm/storm-kafka "0.9.0-wip16b-scala292"
+(defproject storm/storm-kafka "0.9.2-curator1.3.3-scala292"
   :java-source-paths ["src/jvm"]
   :repositories {"scala-tools" "http://scala-tools.org/repo-releases"
                   "conjars" "http://conjars.org/repo/"}
@@ -7,7 +7,7 @@
                   :exclusions [org.apache.zookeeper/zookeeper
                                log4j/log4j]]]
   :profiles
-  {:provided {:dependencies [[storm "0.9.0-wip15"]
+  {:provided {:dependencies [[org.apache.storm/storm-core "0.9.2-incubating"]
                              [org.slf4j/log4j-over-slf4j "1.6.6"]
                              ;;[ch.qos.logback/logback-classic "1.0.6"]
                              [org.clojure/clojure "1.4.0"]]}}

--- a/storm-kafka/project.clj
+++ b/storm-kafka/project.clj
@@ -3,11 +3,14 @@
   :repositories {"scala-tools" "http://scala-tools.org/repo-releases"
                   "conjars" "http://conjars.org/repo/"}
   :dependencies [[org.scala-lang/scala-library "2.9.2"]
+                 [com.netflix.curator/curator-framework "1.3.3"
+                  :exclusions [log4j/log4j
+                               org.slf4j/slf4j-log4j12]]
                   [com.twitter/kafka_2.9.2 "0.7.0"
                   :exclusions [org.apache.zookeeper/zookeeper
                                log4j/log4j]]]
   :profiles
-  {:provided {:dependencies [[org.apache.storm/storm-core "0.9.2-incubating"]
+  {:provided {:dependencies [[org.apache.storm/storm-core "0.9.2-incubating-SNAPSHOT"]
                              [org.slf4j/log4j-over-slf4j "1.6.6"]
                              ;;[ch.qos.logback/logback-classic "1.0.6"]
                              [org.clojure/clojure "1.4.0"]]}}

--- a/storm-kafka/src/jvm/storm/kafka/DynamicBrokersReader.java
+++ b/storm-kafka/src/jvm/storm/kafka/DynamicBrokersReader.java
@@ -29,7 +29,7 @@ public class DynamicBrokersReader {
                     new RetryNTimes(Utils.getInt(conf.get(Config.STORM_ZOOKEEPER_RETRY_TIMES)),
                     Utils.getInt(conf.get(Config.STORM_ZOOKEEPER_RETRY_INTERVAL))));
             _curator.start();
-        } catch (IOException e) {
+        } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }

--- a/storm-kafka/src/jvm/storm/kafka/KafkaSpout.java
+++ b/storm-kafka/src/jvm/storm/kafka/KafkaSpout.java
@@ -145,7 +145,11 @@ public class KafkaSpout extends BaseRichSpout {
         KafkaMessageId id = (KafkaMessageId) msgId;
         PartitionManager m = _coordinator.getManager(id.partition);
         if(m!=null) {
-            m.fail(id.offset);
+            if (_spoutConfig.refetchOnFail) {
+                m.fail(id.offset);
+            } else {
+                m.ack(id.offset);
+            }
         } 
     }
 

--- a/storm-kafka/src/jvm/storm/kafka/PartitionManager.java
+++ b/storm-kafka/src/jvm/storm/kafka/PartitionManager.java
@@ -153,7 +153,6 @@ public class PartitionManager {
             long offset = -1;
             if (_sampleAckCount++ % _spoutConfig.sampleAckRate == 0) {
                 _pending.add(_emittedToOffset);
-                LOG.info("Added emittedOffset : " + _emittedToOffset + " to pending");
                 offset = _emittedToOffset;
                 _emittedToOffset = msg.offset();
                 _sampleAckCount = 1;

--- a/storm-kafka/src/jvm/storm/kafka/SpoutConfig.java
+++ b/storm-kafka/src/jvm/storm/kafka/SpoutConfig.java
@@ -10,6 +10,7 @@ public class SpoutConfig extends KafkaConfig implements Serializable {
     public String zkRoot = null;
     public String id = null;
     public long stateUpdateIntervalMs = 2000;
+    public int sampleAckRate = 1;
 
     public SpoutConfig(BrokerHosts hosts, String topic, String zkRoot, String id) {
         super(hosts, topic);

--- a/storm-kafka/src/jvm/storm/kafka/SpoutConfig.java
+++ b/storm-kafka/src/jvm/storm/kafka/SpoutConfig.java
@@ -11,6 +11,7 @@ public class SpoutConfig extends KafkaConfig implements Serializable {
     public String id = null;
     public long stateUpdateIntervalMs = 2000;
     public int sampleAckRate = 1;
+    public boolean refetchOnFail = true;
 
     public SpoutConfig(BrokerHosts hosts, String topic, String zkRoot, String id) {
         super(hosts, topic);


### PR DESCRIPTION
...k version conflics.

curator-framework-1.0.1 and curator-framework-1.3.3 have different method definition, includeing:
1) netflix.curator.framework.api.CreateBuilder.creatingParentsIfNeeded() has different return types;
2) CuratorFrameworkFactory.newClient(...) doesn't throw IOException anymore in v1.3.3;

When using [storm/storm-kafka "0.9.0-wip16a-scala292"] on storm cluster of [org.apache.storm/storm-core "0.9.2-incubating-SNAPSHOT"], "java.lang.NoSuchMethodError" will thrown.
